### PR TITLE
MavenEbuilder: Don't inherit eutils but java-pkg-2 instead.

### DIFF
--- a/src/main/java/org/gentoo/java/ebuilder/maven/MavenEbuilder.java
+++ b/src/main/java/org/gentoo/java/ebuilder/maven/MavenEbuilder.java
@@ -373,7 +373,7 @@ public class MavenEbuilder {
      */
     private void writeInherit(final PrintWriter writer) {
         writer.println();
-        writer.println("inherit eutils java-pkg-simple");
+        writer.println("inherit java-pkg-2 java-pkg-simple");
     }
 
     /**


### PR DESCRIPTION
There's no need to inherit the eutils eclass since the dep graph goes like this:

eutils.eclass <- java-utils-2.eclass <- java-pkg-2.eclass
