### PR TITLE
org/gentoo/java/ebuilder/maven/MavenParser.java: fix result list

### DIFF
--- a/src/main/java/org/gentoo/java/ebuilder/maven/MavenParser.java
+++ b/src/main/java/org/gentoo/java/ebuilder/maven/MavenParser.java
@@ -49,6 +49,8 @@ public class MavenParser {
                         "junit", "junit", "4.11", "test",
                         mavenCache.getDependency("junit", "junit", "4.11")));
             }
+
+	    result.add(mavenProject);
         });
 
         return result;
@@ -347,6 +349,9 @@ public class MavenParser {
 
                 if (reader.isStartElement()) {
                     switch (reader.getLocalName()) {
+                        case "projects":
+                            /* no-op */
+                            break;
                         case "project":
                             parseProject(mavenProject, mavenCache, reader);
                             break;


### PR DESCRIPTION
1. Parsed objects should be added the returning result ArrayList.
2. Some pom.xml has 'projects' tag enclosing 'project', ignore it if found.
