### PR TITLE
Fix hanging Maven process when lots of artifacts are being downloaded

### DIFF
--- a/src/main/java/org/gentoo/java/ebuilder/maven/MavenParser.java
+++ b/src/main/java/org/gentoo/java/ebuilder/maven/MavenParser.java
@@ -110,6 +110,10 @@ public class MavenParser {
 
         final ProcessBuilder processBuilder = new ProcessBuilder("mvn", "-f",
                 pomFile.toString(), "help:effective-pom",
+                // If output was not suppressed, mvn would hang indefinitely
+                // if new artifact should be downloaded, probably because of
+                // limited output stream buffer size
+                "-q",
                 "-Doutput=" + outputPath);
         processBuilder.directory(config.getWorkdir().toFile());
         final ProcessBuilder xmlBuilder = new ProcessBuilder("simple-xml-formatter",


### PR DESCRIPTION
This pull request fixes an issue where if the Maven process called by java-ebuilder generates a lot of output, then the process may hang and do not make any progress, and as a result, the ebuilds cannot be generated.  The issue can be reproduced easily with the following steps:
1. Delete the contents under the local Maven cache directory (`~/.m2` by default, or `/root/.m2` if the `root` account is used to run java-ebuilder)
2. Use java-ebuilder to generate an ebuild for a Maven artifact with some dependencies.  For example, `com.google.guava:guava:30.1.1-jre` suffices.  The program will just hang here.
3. Now, interrupt the process and re-run java-ebuilder.  It might still hang, in which case just interrupt it and re-run again.  But after a few trials (4 required for Guava as per my testing), it no longer hangs and can successfully complete.

For more information with respect to the issue's root cause and why the patch contained in this pull request can fix it, please read the commit message.