### PR TITLE
Support multi-line value, `${PN}`, and  `${PV}` in `MAVEN_PROVIDES`

### DIFF
--- a/src/main/java/org/gentoo/java/ebuilder/portage/PortageParser.java
+++ b/src/main/java/org/gentoo/java/ebuilder/portage/PortageParser.java
@@ -394,6 +394,9 @@ public class PortageParser {
                 groupId, artifactId, mavenVersion, eclasses));
 
         for (String providedId: mavenProvide) {
+            // Allow declarations like MAVEN_PROVIDES="groupId:${PN}:${PV}"
+            providedId = providedId.replaceAll("\\$(\\{PN\\}|PN)", pkg).
+                    replaceAll("\\$(\\{PV\\}|PV)", pv);
             final String[] parts = providedId.split(":");
             cacheItems.add(new CacheItem(category, pkg, version, slot, useFlag,
                     parts[0], parts[1], parts[2], eclasses));


### PR DESCRIPTION
The commits in this pull request add support for these types of `MAVEN_PROVIDES` value to java-ebuilder:

```bash
MAVEN_PROVIDES="
	org.ow2.asm:asm-bom:9.4
	org.ow2.asm:asm:9.4
"
```

```bash
MAVEN_PROVIDES="org.ow2.asm:${PN}:${PV}"
```

```bash
MAVEN_PROVIDES="
	org.ow2.asm:asm-bom:${PV}
	org.ow2.asm:asm:${PV}
"
```

These commits solve the following problems:
- If `MAVEN_PROVIDES` does not support values broken into multiple lines, then when a package provides multiple Maven artifacts, `MAVEN_PROVIDES` has to be a single, long line, compromising readability and maintainability.
- `MAVEN_ID` supports `${PV}`, but `MAVEN_PROVIDES` does not.